### PR TITLE
Corrections to vMinstaller_linux retain folder

### DIFF
--- a/vMinstaller_linux
+++ b/vMinstaller_linux
@@ -32,7 +32,7 @@ folder () {
 	else
 		answer="miner"
 	fi
-	
+	workdir=$answer
 	mkdir $answer
 	cd $answer
 
@@ -125,7 +125,7 @@ compilex86_64 () {
 			git clone https://github.com/fireworm71/veriumMiner > /dev/null 2>&1
 			cd veriumMiner 
 			./build.sh > /dev/null 2>&1
-                        mv cpuminer ../
+                        mv cpuminer $workdir
 
 		  break;;
 		   
@@ -302,9 +302,9 @@ runme () {
 	  # (2) handle the input we were given 
 	  case $answer in
 	   [yY]* )  
-			poolcreds $2 > RunMe
-			chmod +x RunMe
-			echo "Finished installation. Use ./RunMe in your choosen directory to start mining."
+			poolcreds $2 > $workdir/RunMe
+			chmod a+x $workdir/RunMe
+			echo "Finished installation. Use ./RunMe in your chosen directory to start mining."
 		  break;;
 		   
 	   [nN]* )


### PR DESCRIPTION
Tested on CentOS that the user specified folder gets moved when compiling gcc, so cpuminer and RunMe end up in $folder/gcc-gcc-7_2_0-release/build/ instead of the user chosen folder (where they should go).
These fixes achieve that (tested, as well).-